### PR TITLE
Tb 370 modify fhir mapper to update open him config without reregistration using mediator urn config

### DIFF
--- a/apps/kafka-mapper-microfrontend/package.json
+++ b/apps/kafka-mapper-microfrontend/package.json
@@ -64,6 +64,7 @@
     "@types/webpack-env": "^1.16.2",
     "axios": "^1.6.3",
     "fhirpath": "^3.9.0",
+    "nanoid": "^5.0.4",
     "net": "^1.0.2",
     "react": "^17.0.2",
     "react-dnd": "^16.0.1",

--- a/apps/kafka-mapper-microfrontend/src/components/ConfigEditor/ExpressionPool.tsx
+++ b/apps/kafka-mapper-microfrontend/src/components/ConfigEditor/ExpressionPool.tsx
@@ -2,6 +2,7 @@ import { styled } from "@mui/material/styles";
 import { Box } from "@mui/material";
 import { useFhirMapperConfig } from "../FhirMapperConfigProvider";
 import { DraggableChip } from "./DraggableChip";
+import { nanoid } from "nanoid";
 
 const ListItem = styled("li")(({ theme }) => ({
   margin: theme.spacing(0.5),
@@ -28,8 +29,8 @@ export default function ExpressionPool() {
     >
       {expressions.map((expression) => {
         return (
-          <ListItem key={expression.columnName}>
-            <DraggableChip expression={expression} type="EXPRESSION" />
+          <ListItem key={nanoid()}>
+            <DraggableChip key={nanoid()} expression={expression} type="EXPRESSION" />
           </ListItem>
         );
       })}

--- a/apps/kafka-mapper-microfrontend/src/components/ConfigEditor/Table.tsx
+++ b/apps/kafka-mapper-microfrontend/src/components/ConfigEditor/Table.tsx
@@ -6,6 +6,7 @@ import {
 } from "../FhirMapperConfigProvider";
 import { ExpressionsDropTable } from "./ExpressionsDropTable";
 import { DeleteTableDialog } from "./DeleteTableDialog";
+import { nanoid } from "nanoid";
 
 export function Table({ table }: { table: string }) {
   const { getMappingsByTable, addMappingSchemaItem } = useFhirMapperConfig();
@@ -63,7 +64,7 @@ export function Table({ table }: { table: string }) {
         {expressions.map((item) => {
           return (
             <ExpressionsDropTable
-              key={item.columnName + "-" + table}
+              key={nanoid()}
               expression={item}
               table={table}
             />

--- a/apps/kafka-mapper-microfrontend/src/components/ConfigEditor/TablesContainer.tsx
+++ b/apps/kafka-mapper-microfrontend/src/components/ConfigEditor/TablesContainer.tsx
@@ -1,3 +1,4 @@
+import { nanoid } from "nanoid";
 import { useFhirMapperConfig } from "../FhirMapperConfigProvider";
 import { AddTableDialog } from "./AddTableDialog";
 import { Table } from "./Table";
@@ -8,7 +9,7 @@ export function TablesContainer() {
     <div id="tables-container">
       <AddTableDialog />
       {tables.map((table) => (
-        <Table key={table} table={table} />
+        <Table key={nanoid()} table={table} />
       ))}
     </div>
   );

--- a/apps/kafka-mapper-microfrontend/src/components/FhirMapperConfigProvider.tsx
+++ b/apps/kafka-mapper-microfrontend/src/components/FhirMapperConfigProvider.tsx
@@ -328,22 +328,15 @@ const FhirMapperConfigProvider: React.FC<FhirMapperConfigProviderProps> = ({
    */
   const updateConfigOnServer = async () => {
     setLoading(true);
-    const updatedMediatorConfig = {
-      // copy all existing config properties
-      ...mediatorConfig,
-      // bump the config version
-      version: mediatorConfig
-        ? `${parseInt(mediatorConfig.version.split(".")[0]) + 1}.0.0`
-        : "0.1.0",
-      config: {
-        ...mediatorConfig?.config, // copy all existing config properties
-        fhirMappings: JSON.stringify(mappingSchema), // overwrite the fhirMappings
-      },
-    };
+
+    const newMediatorConfig = {
+      fhirMappings: JSON.stringify(mappingSchema)
+    }
+    const mediatorUrn = mediatorConfig.urn;
     try {
-      const response = await apiClient.post(
-        "mediators/",
-        updatedMediatorConfig
+      const response = await apiClient.put(
+        `/mediators/${mediatorUrn}/config`,
+        newMediatorConfig
       );
       // TODO: handle response status
       if (response.status >= 200 && response.status < 300) {

--- a/apps/kafka-mapper-microfrontend/src/components/FhirResourcesLoader/FhirFileSelector.tsx
+++ b/apps/kafka-mapper-microfrontend/src/components/FhirResourcesLoader/FhirFileSelector.tsx
@@ -8,6 +8,7 @@ import {
 import { useState } from "react";
 import { useFhirMapperConfig } from "../FhirMapperConfigProvider";
 import { FhirResource } from "fhir/r4";
+import { nanoid } from 'nanoid'
 
 // File selector Menu
 export function FhirFileSelector() {
@@ -42,7 +43,7 @@ export function FhirFileSelector() {
           </MenuItem>
           {entries.length > 0 &&
             entries.map((item) => (
-              <MenuItem key={item.fullUrl} value={item.resource.id}>
+              <MenuItem key={nanoid()} value={item.resource.id}>
                 {item.resource.resourceType + " - " + item.resource.id}
               </MenuItem>
             ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6756,6 +6756,11 @@ nanoid@^3.3.7:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
+nanoid@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.4.tgz#d2b608d8169d7da669279127615535705aa52edf"
+  integrity sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"


### PR DESCRIPTION
Updated to using the route '/mediators/:urn/config' when update solely the mediators configurations. This is to prevent the mediators version from being update when ever the config changes.

Additional bug fix, when inserted fhir bundle does not contain certain field the front end app crashes. This due to The mapper makes use of certain values when assigning keys to Components created by .map method. The fix is using nanoid to generate key for those components.